### PR TITLE
Use `FiniteDuration` in schedule

### DIFF
--- a/src/main/scala/async/AsyncSupport.scala
+++ b/src/main/scala/async/AsyncSupport.scala
@@ -1,6 +1,6 @@
 package gears.async
 
-import java.time.Duration
+import scala.concurrent.duration._
 
 trait Suspension[-T, +R]:
     def resume(arg: T): R
@@ -26,7 +26,7 @@ trait AsyncSupport extends SuspendSupport:
 
 trait Scheduler:
     def execute(body: Runnable): Unit
-    def schedule(delay: Duration, body: Runnable): Cancellable
+    def schedule(delay: FiniteDuration, body: Runnable): Cancellable
 
 object AsyncSupport:
     inline def apply()(using ac: AsyncSupport) = ac

--- a/src/main/scala/async/VThreadSupport.scala
+++ b/src/main/scala/async/VThreadSupport.scala
@@ -2,7 +2,7 @@ package gears.async
 
 import scala.annotation.unchecked.uncheckedVariance
 import java.util.concurrent.locks.ReentrantLock
-import java.time.Duration
+import scala.concurrent.duration.FiniteDuration
 
 given VThreadScheduler.type = VThreadScheduler
 given VThreadSupport.type = VThreadSupport
@@ -10,9 +10,9 @@ given VThreadSupport.type = VThreadSupport
 object VThreadScheduler extends Scheduler:
   override def execute(body: Runnable): Unit = Thread.startVirtualThread(body)
 
-  override def schedule(delay: Duration, body: Runnable): Cancellable =
+  override def schedule(delay: FiniteDuration, body: Runnable): Cancellable =
     val th = Thread.startVirtualThread: () =>
-      Thread.sleep(delay)
+      Thread.sleep(delay.toMillis)
       body.run()
     () => th.interrupt() // TODO this may interrupt the body after sleeping
 


### PR DESCRIPTION
... instead of `java.util.Duration`.

This makes it more Scala-like? :D
